### PR TITLE
Refactor Chat History API to Use Secure POST Request with Seller ID in Body

### DIFF
--- a/src/main/java/com/gemora_server/dto/ChatHistoryRequestDto.java
+++ b/src/main/java/com/gemora_server/dto/ChatHistoryRequestDto.java
@@ -1,0 +1,8 @@
+package com.gemora_server.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatHistoryRequestDto {
+    private Long sellerId;
+}

--- a/src/main/java/com/gemora_server/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/gemora_server/service/impl/ChatMessageServiceImpl.java
@@ -36,13 +36,18 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         return toResponse(saved);
     }
 
-    public List<ChatMessageResponseDto> getChatHistory(Long user1Id, Long user2Id) {
-        String roomId = generateRoomId(user1Id, user2Id);
+    public List<ChatMessageResponseDto> getChatHistory(Long buyerId, Long sellerId) {
+
+        // Generate unique roomId for the chat between buyer & seller
+        String roomId = generateRoomId(buyerId, sellerId);
+
+        // Fetch messages ordered by sent time ascending
         return chatMessageRepository.findByRoomIdOrderBySentAtAsc(roomId)
                 .stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
+
 
     private ChatMessageResponseDto toResponse(ChatMessage msg) {
         return ChatMessageResponseDto.builder()


### PR DESCRIPTION
Replaced the old GET /api/chat/history endpoint with a secure POST /api/chat/history request.

Buyer ID is now extracted directly from the JWT token rather than being passed in query params.

Introduced a new ChatHistoryRequestDto to correctly accept sellerId in the request body.

Updated service logic to use (buyerId, sellerId) for generating room IDs.

Fixed NullPointerException caused by incorrect DTO usage during history retrieval.

Improved endpoint structure for future scalability (pagination, filters, unread messages, etc.).
<img width="1450" height="904" alt="image" src="https://github.com/user-attachments/assets/ad82c966-684c-4e01-b531-94040140e388" />

